### PR TITLE
Test configuration fix 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,8 @@ libraryDependencies ++= Seq(
   "org.apache.logging.log4j"   % "log4j-core"                     % log4jVersion      % Runtime,
   "org.apache.logging.log4j"  %% "log4j-api-scala"                % "12.0",
 
-  "org.apache.flink"          %% "flink-scala"                    % flinkVersion      % Provided,
-  "org.apache.flink"          %% "flink-streaming-scala"          % flinkVersion      % Provided,
+  "org.apache.flink"          %% "flink-scala"                    % flinkVersion,
+  "org.apache.flink"          %% "flink-streaming-scala"          % flinkVersion,
   "org.apache.flink"          %% "flink-connector-kafka"          % flinkVersion,
   "org.apache.flink"          %% "flink-clients"                  % flinkVersion,
 
@@ -41,7 +41,7 @@ libraryDependencies ++= Seq(
   "org.apache.avro"            % "avro"                           % "1.10.1",
   "com.sksamuel.avro4s"       %% "avro4s-core"                    % "4.0.3",
 
-  "org.apache.flink"          %% "flink-table-api-scala-bridge"   % flinkVersion      % Provided,
+  "org.apache.flink"          %% "flink-table-api-scala-bridge"   % flinkVersion,
   "org.apache.flink"          %% "flink-table-planner-blink"      % flinkVersion,
   "org.apache.flink"           % "flink-json"                     % flinkVersion,
 

--- a/build.sbt
+++ b/build.sbt
@@ -51,3 +51,6 @@ libraryDependencies ++= Seq(
 
   "com.github.scopt"          %% "scopt"                          % "4.0.0"
 )
+
+// Fork all tasks
+fork := true

--- a/src/main/scala/org/codefeedr/kafkaquery/commands/QueryCommand.scala
+++ b/src/main/scala/org/codefeedr/kafkaquery/commands/QueryCommand.scala
@@ -52,7 +52,8 @@ class QueryCommand(
         topicName,
         QuerySetup.generateTableSchema(result.get, getNestedSchema),
         kafkaAddr,
-        qConfig.checkLatest
+        qConfig.checkLatest,
+        qConfig.ignoreParseErr
       )
 
       fsTableEnv.executeSql(ddlString)

--- a/src/main/scala/org/codefeedr/kafkaquery/parsers/Configurations.scala
+++ b/src/main/scala/org/codefeedr/kafkaquery/parsers/Configurations.scala
@@ -35,6 +35,7 @@ object Configurations {
     * @param port        socket port number
     * @param timeout     timeout before query prints results
     * @param checkLatest check if the query output should be printed from latest
+    * @param ignoreParseErr ignore JSON parse errors during deserialization
     * @param pack        generate JAR which can be deployed to Flink cluster
     */
   case class QueryConfig(
@@ -45,6 +46,7 @@ object Configurations {
       timeoutFunc: () => Unit = () => System.exit(0),
       checkEarliest: Boolean = false,
       checkLatest: Boolean = false,
+      ignoreParseErr: Boolean = true,
       pack: Boolean = false
   )
 }

--- a/src/main/scala/org/codefeedr/kafkaquery/parsers/Parser.scala
+++ b/src/main/scala/org/codefeedr/kafkaquery/parsers/Parser.scala
@@ -1,6 +1,7 @@
 package org.codefeedr.kafkaquery.parsers
 
 import java.io.File
+import java.nio.charset.Charset
 
 import org.apache.avro.Schema
 import org.apache.commons.io.FileUtils
@@ -92,7 +93,7 @@ class Parser extends OptionParser[Config]("codefeedr") {
     .action({ case ((topicName, schema), c) =>
       c.copy(
         mode = Mode.Schema,
-        avroSchema = FileUtils.readFileToString(schema),
+        avroSchema = FileUtils.readFileToString(schema, Charset.defaultCharset()),
         topicName = topicName
       )
     })

--- a/src/main/scala/org/codefeedr/kafkaquery/parsers/Parser.scala
+++ b/src/main/scala/org/codefeedr/kafkaquery/parsers/Parser.scala
@@ -93,7 +93,8 @@ class Parser extends OptionParser[Config]("codefeedr") {
     .action({ case ((topicName, schema), c) =>
       c.copy(
         mode = Mode.Schema,
-        avroSchema = FileUtils.readFileToString(schema, Charset.defaultCharset()),
+        avroSchema =
+          FileUtils.readFileToString(schema, Charset.defaultCharset()),
         topicName = topicName
       )
     })

--- a/src/main/scala/org/codefeedr/kafkaquery/transforms/QuerySetup.scala
+++ b/src/main/scala/org/codefeedr/kafkaquery/transforms/QuerySetup.scala
@@ -24,13 +24,15 @@ object QuerySetup {
     * @param tableFields DDL StringBuilder of the table fields
     * @param kafkaAddr Kafka server address
     * @param checkLatest record retrieval strategy (from LATEST or EARLIEST)
+    * @param ignoreParseErr JSON ignore parse errors property
     * @return temporary table DDL string
     */
   def getTableCreationCommand(
       name: String,
       tableFields: java.lang.StringBuilder,
       kafkaAddr: String,
-      checkLatest: Boolean
+      checkLatest: Boolean,
+      ignoreParseErr: Boolean
   ): String = {
     "CREATE TEMPORARY TABLE `" + name + "` (" + tableFields + ") " +
       "WITH (" +
@@ -39,12 +41,12 @@ object QuerySetup {
       "'properties.bootstrap.servers' = '" + kafkaAddr + "', " +
       "'properties.group.id' = 'kq', " +
       "'scan.startup.mode' = '" +
-      (if (checkLatest) "latest-offset" else "earliest-offset") +
-      "', " +
+      (if (checkLatest) "latest-offset" else "earliest-offset") + "', " +
       "'properties.default.api.timeout.ms' = '5000', " + // TODO create option for setting this value
       "'format' = 'json', " +
       "'json.timestamp-format.standard' = 'ISO-8601', " +
-      "'json.ignore-parse-errors' = 'true', " +
+      "'json.ignore-parse-errors' = '" +
+      (if (ignoreParseErr) "true" else "false") + "', " +
       "'json.fail-on-missing-field' = 'false'" +
       ")"
   }

--- a/src/test/scala/org/codefeedr/kafkaquery/transforms/JsonToAvroSchemaTest.scala
+++ b/src/test/scala/org/codefeedr/kafkaquery/transforms/JsonToAvroSchemaTest.scala
@@ -1,14 +1,10 @@
 package org.codefeedr.kafkaquery.transforms
 
-import java.io.InputStream
-
 import org.apache.avro.Schema
 import org.codefeedr.kafkaquery.util.{KafkaRecordRetriever, UserInputRetriever}
 import org.mockito.MockitoSugar
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1, TableFor2, TableFor3}
-
-import scala.io.StdIn
 
 class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks with MockitoSugar {
 

--- a/src/test/scala/org/codefeedr/kafkaquery/transforms/QuerySetupTest.scala
+++ b/src/test/scala/org/codefeedr/kafkaquery/transforms/QuerySetupTest.scala
@@ -27,12 +27,12 @@ class QuerySetupTest extends AnyFunSuite with BeforeAndAfter with TableDrivenPro
     val kafkaAddr = "localhost:9092"
 
     assertResult(
-      s"CREATE TEMPORARY TABLE `t1` ((f1 INT, f2 STRING)) WITH ('connector.type' = 'kafka', " +
-        s"'connector.version' = 'universal', 'connector.topic' = 't1', 'connector.properties.bootstrap.servers' " +
-        s"= 'localhost:9092', 'connector.startup-mode' = '$offsetText', " +
-        "'connector.properties.default.api.timeout.ms' = '5000', " +
-        s"'format.type' = 'json', " +
-        s"'format.fail-on-missing-field' = 'false')"
+      s"CREATE TEMPORARY TABLE `t1` ((f1 INT, f2 STRING)) WITH ('connector' = 'kafka', " +
+        s"'topic' = '$tableName', 'properties.bootstrap.servers' = '$kafkaAddr', " +
+        s"'properties.group.id' = 'kq', 'scan.startup.mode' = '$offsetText', " +
+        "'properties.default.api.timeout.ms' = '5000', 'format' = 'json', " +
+        "'json.timestamp-format.standard' = 'ISO-8601', 'json.ignore-parse-errors' = 'true', " +
+        "'json.fail-on-missing-field' = 'false')"
     )(
       QuerySetup.getTableCreationCommand(tableName, new java.lang.StringBuilder(tableFields), kafkaAddr,
         checkLatest = checkLatest)
@@ -54,7 +54,7 @@ class QuerySetupTest extends AnyFunSuite with BeforeAndAfter with TableDrivenPro
           |     ]
           |}
           |""".stripMargin,
-        "field field type, field field type, `kafka_time` AS PROCTIME()"
+        "field field type, field field type, `kafka_time` TIMESTAMP(3) METADATA FROM 'timestamp'"
       ),
       (
         """
@@ -81,7 +81,7 @@ class QuerySetupTest extends AnyFunSuite with BeforeAndAfter with TableDrivenPro
           |     ]
           |}
           |""".stripMargin,
-        "field field type, field TIMESTAMP(3), WATERMARK FOR field AS field - INTERVAL '0.001' SECOND"
+        "field field type, field TIMESTAMP(3) WITH LOCAL TIME ZONE"
       )
     )
   forAll(testDataGenerateTableSchema) { (schemaStr: String, tableDesc: String) =>

--- a/src/test/scala/org/codefeedr/kafkaquery/transforms/QuerySetupTest.scala
+++ b/src/test/scala/org/codefeedr/kafkaquery/transforms/QuerySetupTest.scala
@@ -35,7 +35,7 @@ class QuerySetupTest extends AnyFunSuite with BeforeAndAfter with TableDrivenPro
         "'json.fail-on-missing-field' = 'false')"
     )(
       QuerySetup.getTableCreationCommand(tableName, new java.lang.StringBuilder(tableFields), kafkaAddr,
-        checkLatest = checkLatest)
+        checkLatest = checkLatest, ignoreParseErr = true)
     )
   }
 


### PR DESCRIPTION
 QueryCommandTest was unable to properly terminate with the 'json.ignore-parse-errors' option set to true, because it relies on sending an invalid message through Kafka in order to trigger an exception which stops query execution before assessing the correctness of results in a custom sink.
A new flag was added to QueryConfig specifying whether this option should be set to true in order to accomodate for the situation, but the flag is not exposed to the user.
Nevertheless, the current flow of setting properties should be revamped in the future to allow for easier expandability and internal handling.