### PR TITLE
Travis config update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ script:
 
 after_success:
   - sbt coverageReport coveralls
-  - sbt "set version := \"$TRAVIS_TAG\"" packArchive
 
 deploy:
   provider: releases
+  script: sbt "set version := \"$TRAVIS_TAG\"" packArchive
   api_key: $API_KEY
   file: "$TRAVIS_BUILD_DIR/target/kafkaquery-$TRAVIS_TAG.tar.gz"
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ after_success:
 
 deploy:
   provider: releases
-  api_key: $API_KEY
+  api_key:
+    secure: "CK5L8+M9mE+V083UU+GZ8fcieG7Cwq/ksk+P99V1MLJRiJcm+jFPJMx5TVBuhCW2jFIf4XlnLzpmpJtERIOPEo+oi7RprAzz8kbAKFc/MNfrVrAXolpY29jx8O7kW76BigiVQ7VtpXC37Thqg4TAcZ6dh9ltg33iUX3CHHu2sFq79wiNmFQ5Yj19kqoCnMX+FB7aOtpgYz6FuKCASXIXM4K/O621Qtofll/qJyls0vqK/83Fm8g4OFt8CaW8Ky7HLgorMnTZe6sqhPTTETAhYkUJVZ+R27CpsqIfzEle3+mV5zibjOdqFrn3OYLMRoyX2HBAXPDdT87kDw/K0x6t7EdMd4nJXwA2okZP+aN5RfuXBuN/raGJMpP9D1EhcmK9G7a1aS806Fk19qx058R5ug1BDOHoVR1LqCHeWIDrHDNrwB1Vv22RzYbMp3JlqJy3Ep3fxZ1qZlXMwOW8yG5tL/oZMxkoWIAWz2+IblGtazgec48/Mdm9qndN3Hv1FXWMkoCFTZWYzFqLBAHXUqgzx0KIsK8Kwn8tFhmwuIyBbk9sAt5+mi9tH4dZPLUC3dwdT/36sLimFhmfNHnidNaBr4UsInqk+/QHNkYK+cWNdW2as6VTLHImK91pTo8+xH1371N2FuHb9OLLI3xJWV0ONcuQ/CaY7rmKknFWdevfYjM="
   file:
     - "$TRAVIS_BUILD_DIR/target/kafkaquery-$TRAVIS_TAG.tar.gz"
     - "$TRAVIS_BUILD_DIR/target/kafkaquery-$TRAVIS_TAG.zip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.12.12
+  - 2.12.13
 jdk: openjdk11
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.12.13
+  - 2.12.12
 jdk: openjdk11
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,11 @@ cache:
     - $HOME/.sbt
 
 script:
+  - echo $TRAVIS_SCALA_VERSION
   - sbt clean coverage test
   - sbt scalafmtCheck
 
 after_success:
   - sbt coverageReport coveralls
+  - echo $TRAVIS_TAG
+  - sbt set version := $TRAVIS_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ script:
 
 after_success:
   - sbt coverageReport coveralls
-  - sbt 'set version := "$TRAVIS_TAG"'
-  - sbt packArchive
+  - sbt "set version := \"$TRAVIS_TAG\"" packArchive
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ script:
 
 after_success:
   - sbt coverageReport coveralls
+  - sbt "set version := \"$TRAVIS_TAG\"" packArchive
 
 deploy:
   provider: releases
-  script: sbt "set version := \"$TRAVIS_TAG\"" packArchive
   api_key: $API_KEY
   file: "$TRAVIS_BUILD_DIR/target/kafkaquery-$TRAVIS_TAG.tar.gz"
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
 language: scala
 scala:
-  - 2.12.8
-sudo: required
-dist: xenial
+  - 2.12.12
 jdk: openjdk11
 
 before_cache:
-  # Cleanup the cached directories to avoid unnecessary cache updates
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt        -name "*.lock"               -print -delete
 
 cache:
   directories:
+    - $HOME/.cache/coursier
     - $HOME/.ivy2/cache
     - $HOME/.sbt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,12 @@ script:
 
 after_success:
   - sbt coverageReport coveralls
-  - sbt set version := $TRAVIS_TAG
+  - sbt 'set version := "$TRAVIS_TAG"'
   - sbt packArchive
 
 deploy:
   provider: releases
-  api_key:
-    secure: $ENCRYPTED_API_KEY
+  api_key: $API_KEY
   file: "$TRAVIS_BUILD_DIR/target/kafkaquery-$TRAVIS_TAG.tar.gz"
   skip_cleanup: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,11 @@ after_success:
   - sbt coverageReport coveralls
   - echo $TRAVIS_TAG
   - sbt set version := $TRAVIS_TAG
+
+deploy:
+  provider: releases
+  api_key:
+    secure: $ENCRYPTED_API_KEY
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,19 +15,19 @@ cache:
     - $HOME/.sbt
 
 script:
-  - echo $TRAVIS_SCALA_VERSION
   - sbt clean coverage test
   - sbt scalafmtCheck
 
 after_success:
   - sbt coverageReport coveralls
-  - echo $TRAVIS_TAG
   - sbt set version := $TRAVIS_TAG
+  - sbt packArchive
 
 deploy:
   provider: releases
   api_key:
     secure: $ENCRYPTED_API_KEY
+  file: "$TRAVIS_BUILD_DIR/target/kafkaquery-$TRAVIS_TAG.tar.gz"
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,17 @@ script:
 
 after_success:
   - sbt coverageReport coveralls
-  - sbt "set version := \"$TRAVIS_TAG\"" packArchive
+  - |
+    if [ ! -z $TRAVIS_TAG ]; then
+      sbt "set version := \"$TRAVIS_TAG\"" packArchive
+    fi
 
 deploy:
   provider: releases
   api_key: $API_KEY
-  file: "$TRAVIS_BUILD_DIR/target/kafkaquery-$TRAVIS_TAG.tar.gz"
+  file:
+    - "$TRAVIS_BUILD_DIR/target/kafkaquery-$TRAVIS_TAG.tar.gz"
+    - "$TRAVIS_BUILD_DIR/target/kafkaquery-$TRAVIS_TAG.zip"
   skip_cleanup: true
   on:
     tags: true

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,5 @@
 name := "kafkaquery"
 
-version := "0.1"
-
 scalaVersion := "2.12.12"
 
 scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,3 @@ libraryDependencies ++= Seq(
 
 // Fork all tasks
 fork := true
-
-import xerial.sbt.pack.PackPlugin._
-publishPackArchiveTgz

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "kafkaquery"
 
 version := "0.1"
 
-scalaVersion := "2.12.13"
+scalaVersion := "2.12.12"
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ enablePlugins(PackPlugin)
 packMain := Map("codefeedr" -> "org.codefeedr.kafkaquery.CLI")
 
 lazy val flinkVersion       = "1.12.0"
+lazy val kafkaVersion       = "2.7.0"
 lazy val log4jVersion       = "2.14.0"
 lazy val scalatestVersion   = "3.2.3"
 
@@ -36,7 +37,8 @@ libraryDependencies ++= Seq(
   "org.scalatest"             %% "scalatest"                      % scalatestVersion  % Test,
   "org.mockito"               %% "mockito-scala"                  % "1.16.15"         % Test,
 
-  "io.github.embeddedkafka"   %% "embedded-kafka"                 % "2.7.0"         % Test,
+  "org.apache.kafka"           % "kafka-clients"                  % kafkaVersion,
+  "io.github.embeddedkafka"   %% "embedded-kafka"                 % kafkaVersion      % Test,
 
   "org.apache.avro"            % "avro"                           % "1.10.1",
   "com.sksamuel.avro4s"       %% "avro4s-core"                    % "4.0.4",
@@ -54,3 +56,6 @@ libraryDependencies ++= Seq(
 
 // Fork all tasks
 fork := true
+
+import xerial.sbt.pack.PackPlugin._
+publishPackArchiveTgz

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "kafkaquery"
 
 version := "0.1"
 
-scalaVersion := "2.12.12"
+scalaVersion := "2.12.13"
 
 scalacOptions ++= Seq(
   "-deprecation",


### PR DESCRIPTION
- update Travis CI caching strategy & upgrade used Scala version to 2.12;
- enable automatic creation of Github releases which include zip and targz binaries upon tag creation;
- sync `kafka-clients` and `embedded-kafka` dependency versions in build.sbt.