### PR TITLE
Ensure backwards compatibility with Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: scala
 scala:
   - 2.12.12
-jdk: openjdk11
+jdk:
+  - openjdk8
+  - openjdk11
 
 before_cache:
   - rm -fv $HOME/.ivy2/.sbt.ivy.lock

--- a/src/main/scala/org/codefeedr/kafkaquery/commands/QueryCommand.scala
+++ b/src/main/scala/org/codefeedr/kafkaquery/commands/QueryCommand.scala
@@ -3,7 +3,6 @@ package org.codefeedr.kafkaquery.commands
 import org.apache.flink.api.java.functions.NullByteKeySelector
 import org.apache.flink.configuration.{Configuration, TaskManagerOptions}
 import org.apache.flink.runtime.client.JobExecutionException
-import org.apache.flink.streaming.api.scala._
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment, _}
 import org.apache.flink.table.api.EnvironmentSettings
 import org.apache.flink.table.api.bridge.scala.{

--- a/src/main/scala/org/codefeedr/kafkaquery/transforms/JsonToAvroSchema.scala
+++ b/src/main/scala/org/codefeedr/kafkaquery/transforms/JsonToAvroSchema.scala
@@ -7,9 +7,7 @@ import org.apache.avro.SchemaBuilder.TypeBuilder
 import org.apache.avro.{Schema, SchemaBuilder}
 import org.codefeedr.kafkaquery.util.{KafkaRecordRetriever, UserInputRetriever}
 
-import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
-import scala.io.StdIn
 
 object JsonToAvroSchema {
 
@@ -207,7 +205,7 @@ object JsonToAvroSchema {
   private def validName(name: String): String = {
     val tempName = name.replaceAll("\\W", "_")
     if (
-      !name.isBlank &&
+      name.nonEmpty &&
       (tempName.charAt(0).isLetter || tempName.charAt(0) == '_')
     )
       return tempName

--- a/src/main/scala/org/codefeedr/kafkaquery/transforms/TimeOutFunction.scala
+++ b/src/main/scala/org/codefeedr/kafkaquery/transforms/TimeOutFunction.scala
@@ -45,7 +45,7 @@ class TimeOutFunction( // delay after which an alert flag is thrown
     val timeoutTime = currentTime + timeOut
 
     if (isTimerRunning.value()) { //if a timer is running already, update the offset
-      timerOffset.update(lastTimer.value() - currentTime);
+      timerOffset.update(lastTimer.value() - currentTime)
     } else { //if no timer is running create new Timer
       ctx.timerService.registerProcessingTimeTimer(timeoutTime)
 

--- a/src/test/scala/org/codefeedr/kafkaquery/commands/QueryCommandTest.scala
+++ b/src/test/scala/org/codefeedr/kafkaquery/commands/QueryCommandTest.scala
@@ -55,7 +55,7 @@ class QueryCommandTest extends AnyFunSuite with BeforeAndAfter with EmbeddedKafk
         case _: JobExecutionException =>
       }
 
-      assertResult(util.List.of(Row.of("val1"), Row.of("val2")))(CollectRowSink.values)
+      assertResult(util.Arrays.asList(Row.of("val1"), Row.of("val2")))(CollectRowSink.values)
     }
 
   }
@@ -110,7 +110,7 @@ class QueryCommandTest extends AnyFunSuite with BeforeAndAfter with EmbeddedKafk
         case _: JobExecutionException =>
       }
 
-      assertResult(util.List.of(Row.of("val1 : udf invoked"), Row.of("val2 : udf invoked")))(CollectRowSink.values)
+      assertResult(util.Arrays.asList(Row.of("val1 : udf invoked"), Row.of("val2 : udf invoked")))(CollectRowSink.values)
     }
 
   }


### PR DESCRIPTION
- remove Java 11 specific functions from code;
- configure Travis CI to test against both Java 8 and 11;
- clean up a few unused imports.